### PR TITLE
Added volume_type field function.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ entry_points = """
     usage_end_date=usage.fields.reading:usage_end_date
     usage_start_date=usage.fields.reading:usage_start_date
     usage_type=usage.fields.item:usage_type
+    volume_type=usage.fields.reading:volume_type
     [usage.licensers]
     OracleCount=usage.licensing.oracle:CountLicenser
     OracleHours=usage.licensing.oracle:HourLicenser

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -13,7 +13,8 @@ class TestConsoleSummary(unittest.TestCase):
     """Tests the Console Summary function."""
     @mock.patch('usage.console.logger')
     @mock.patch('usage.console.config')
-    @mock.patch('usage.console.ClientManager')
+    #@mock.patch('usage.console.ClientManager')
+    @mock.patch('usage.console.create_client_manager')
     @mock.patch('usage.console.summary_parser.parse_args')
     @mock.patch('usage.console.Summary')
     def test_console_summary(self,

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -31,6 +31,7 @@ from usage.fields.reading import usage_account_id
 from usage.fields.reading import usage_amount
 from usage.fields.reading import usage_end_date
 from usage.fields.reading import usage_start_date
+from usage.fields.reading import volume_type
 from usage.fields.report import invoice_id
 from usage.exc import UnknownFieldFunctionError
 
@@ -364,3 +365,20 @@ class TestDescription(unittest.TestCase):
         i = {'description': 'description'}
         self.assertTrue(description(None, {}, None) is '')
         self.assertEquals(description(None, i, None), 'description')
+
+
+class TestVolumeType(unittest.TestCase):
+    """Tests the volume_type field function."""
+
+    @mock.patch(
+        'usage.fields.reading.volume_types.name_from_id',
+        return_value='test_volume_name'
+    )
+    def test_volume_type_none(self, mock_name_from_id):
+        metadata = {}
+        r = FakeReading(metadata=metadata)
+        self.assertEquals('test_volume_name', volume_type(None, None, r))
+
+        metadata = {'volume_type': 'some-id'}
+        r = FakeReading(metadata=metadata)
+        self.assertEquals('test_volume_name', volume_type(None, None, r))

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,7 +18,7 @@ class TestStream(unittest.TestCase):
 
 class TestFile(unittest.TestCase):
     @mock.patch('usage.output.os.makedirs')
-    @mock.patch('usage.output.open')
+    @mock.patch('__builtin__.open')
     def test_init(self, m_open, m_makedirs):
         name = '/somewhere/somefile.csv'
         f = output.File(name)
@@ -30,7 +30,7 @@ class TestFile(unittest.TestCase):
 class TestMtd(unittest.TestCase):
     @mock.patch('usage.output.File')
     @mock.patch('usage.output.os.makedirs')
-    @mock.patch('usage.output.open')
+    @mock.patch('__builtin__.open')
     def test_init(self, m_open, m_makedirs, m_file):
         year = 2016
         month = 1
@@ -44,7 +44,7 @@ class TestMtd(unittest.TestCase):
 class TestDaily(unittest.TestCase):
     @mock.patch('usage.output.File')
     @mock.patch('usage.output.os.makedirs')
-    @mock.patch('usage.output.open')
+    @mock.patch('__builtin__.open')
     def test_init(self, m_open, m_makedirs, m_file):
         year = 2016
         month = 1
@@ -58,7 +58,7 @@ class TestDaily(unittest.TestCase):
 class TestOther(unittest.TestCase):
     @mock.patch('usage.output.File')
     @mock.patch('usage.output.os.makedirs')
-    @mock.patch('usage.output.open')
+    @mock.patch('__builtin__.open')
     def test_init(self, m_open, m_makedirs, m_file):
         stop = datetime.datetime.utcnow()
         start = stop - datetime.timedelta(hours=1)

--- a/tests/test_volume_types.py
+++ b/tests/test_volume_types.py
@@ -1,0 +1,68 @@
+import mock
+import unittest
+
+from usage.fields import volume_types
+
+
+class FakeVolumeType:
+    """Model a fake volume type returned by a cinder client."""
+
+    def __init__(self, id, name):
+        """Init the fake volume type
+
+        :param id: Id of the volume type
+        :type id: str
+        :param name: Name of the volume type
+        :type name: str
+        """
+        self.id = id
+        self.name = name
+
+
+class FakeVolumeTypes:
+    """Model the fake volume_types portion of the cinder client."""
+
+    def list(self):
+        """Return a list of fake volume types.
+
+        :returns: List of fake volume types
+        :rtype: list
+        """
+        return [
+            FakeVolumeType('1', 'lvm'),
+            FakeVolumeType('2', 'ceph')
+        ]
+
+
+class FakeCinderClient:
+    """Model a cinder client for testing purposes."""
+
+    def __init__(self):
+        self.volume_types = FakeVolumeTypes()
+
+
+class FakeClientManager:
+    """Model the client manager."""
+
+    def get_cinder(self):
+        """Returns an instance of the fake cinder client.
+
+        :returns: A fake cinder client
+        :rtype: FakeCinderClient
+        """
+        return FakeCinderClient()
+
+
+class TestVolumeTypes(unittest.TestCase):
+
+    @mock.patch(
+        'usage.fields.volume_types.get_client_manager',
+        return_value=FakeClientManager()
+    )
+    def test_load_when_none(self, mocked_get):
+        self.assertEquals('lvm', volume_types.name_from_id('1'))
+        self.assertEquals('ceph', volume_types.name_from_id('2'))
+        # Test a known id but no mapping for the id
+        self.assertTrue(volume_types.name_from_id('3') is None)
+        # Test not having an id.
+        self.assertTrue(volume_types.name_from_id(None) is None)

--- a/usage/console.py
+++ b/usage/console.py
@@ -6,7 +6,7 @@ import utils
 
 from args.report import parser as report_parser
 from args.summary import parser as summary_parser
-from clients import ClientManager
+from clients import create_client_manager
 from log import logging
 from report import Report
 from summary import Summary
@@ -29,7 +29,7 @@ def console_licensing():
     args = licensing_parser.parse_args()
     conf = config.load(args.config_file)
     logger.setLevel(LOG_LEVELS.get(args.log_level.lower(), 'info'))
-    clientmanager = ClientManager(**conf.get('auth_kwargs', {}))
+    clientmanager = create_client_manager(**conf.get('auth_kwargs', {}))
     set_domain_client(clientmanager.get_domain())
     Licensing(
         definition_file=args.definition_file,
@@ -42,7 +42,7 @@ def console_summary():
     args = summary_parser.parse_args()
     conf = config.load(args.config_file)
     logger.setLevel(LOG_LEVELS.get(args.log_level.lower(), 'info'))
-    clientmanager = ClientManager(**conf.get('auth_kwargs', {}))
+    clientmanager = create_client_manager(**conf.get('auth_kwargs', {}))
     Summary(
         domain_client=clientmanager.get_domain(),
         input_file=args.csv_file,
@@ -58,7 +58,7 @@ def console_report():
     conf = config.load(args.config_file)
     logger.setLevel(LOG_LEVELS.get(args.log_level.lower(), 'info'))
 
-    manager = ClientManager(**conf.get('auth_kwargs', {}))
+    manager = create_client_manager(**conf.get('auth_kwargs', {}))
     ceilometer = manager.get_ceilometer()
 
     out = output.Stream() if args.use_stdout else None

--- a/usage/fields/reading.py
+++ b/usage/fields/reading.py
@@ -1,4 +1,5 @@
 import ast
+import volume_types
 
 from usage import tag
 from usage.conversions.time_units import seconds_to_hours
@@ -352,3 +353,19 @@ def usage_start_date(d, i, r):
     :rtype: String
     """
     return r.usage_start.isoformat()
+
+
+def volume_type(d, i, r):
+    """Get volume type from reading.
+
+    :param d: Report definition.
+    :type d: Dict
+    :param i: Item definition
+    :type i: dict
+    :param r: Meter reading
+    :type r: usage.reading.Reading
+    :return: Human readable name of volume type
+    :rtype: str
+    """
+    volume_type_id = r.metadata.get('volume_type')
+    return volume_types.name_from_id(volume_type_id)

--- a/usage/fields/volume_types.py
+++ b/usage/fields/volume_types.py
@@ -1,0 +1,41 @@
+import logging
+import pprint
+from usage.clients import get_client_manager
+
+logger = logging.getLogger('usage.fields.volume_types')
+_TYPE_MAP = None
+
+
+def _load_type_map():
+    """Load a map of volume type ids to names.
+
+    Store the result in the module variable _TYPE_MAP
+    """
+    global _TYPE_MAP
+    try:
+        cinder = get_client_manager().get_cinder()
+        volume_types = cinder.volume_types.list()
+        _TYPE_MAP = {t.id: t.name for t in volume_types}
+    except Exception:
+        logger.exception('Unable to load volume types.')
+        _TYPE_MAP = {}
+
+
+def name_from_id(type_id):
+    """Get the volume type name from the volume type id.
+
+    :param type_id: Volume type id
+    :type type_id: str
+    :returns: The name of the volume type
+    :rtype: str
+    """
+    # Load the type map on the first use
+    if _TYPE_MAP is None:
+        _load_type_map()
+
+    # Don't bother if we do not have a type id
+    if type_id is None:
+        return None
+
+    # Return the type name for the given type id
+    return _TYPE_MAP.get(type_id)

--- a/usage/meta.py
+++ b/usage/meta.py
@@ -1,2 +1,2 @@
-version = '0.1.2'
+version = '0.1.3'
 description = "Python tool for collecting usage information from ceilometer."


### PR DESCRIPTION
Volume types in ceilometer samples are stored as uuids. This
change adds a way to convert volume type uuids to volume type names.
One the first call to the volume_type field function, the cinder
client is used to gather a list of volume types. This is cached and
usable for every volume resource afterwards. If volume_type is never
used, the cinder client will not be invoked to load volume types.